### PR TITLE
テスト追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ captures/
 .idea/navEditor.xml
 # Android Studio Arctic Fox in .gitignore file.
 .idea/deploymentTargetDropDown.xml
+# remove user-specific files of ui tests
+.idea/androidTestResultsUserPreferences.xml
 
 # Keystore files
 # Uncomment the following lines if you do not want to check your keystore files in.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -65,4 +65,11 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-contrib:3.4.0'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test:rules:1.0.2'
+}
+
+configurations.all {
+    resolutionStrategy.force 'com.android.support:support-annotations:3.1.1'
 }

--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/ExampleInstrumentedTest.kt
@@ -17,6 +17,6 @@ class ExampleInstrumentedTest {
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
-        assertEquals("jp.co.yumemi.android.codecheck", appContext.packageName)
+        assertEquals("jp.co.yumemi.android.code_check", appContext.packageName)
     }
 }

--- a/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/SearchFragmentTest.kt
+++ b/app/src/androidTest/kotlin/jp/co/yumemi/android/code_check/SearchFragmentTest.kt
@@ -1,0 +1,59 @@
+package jp.co.yumemi.android.code_check
+
+
+import androidx.test.espresso.DataInteraction
+import androidx.test.espresso.ViewInteraction
+import androidx.test.filters.LargeTest
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewParent
+
+import androidx.test.InstrumentationRegistry.getInstrumentation
+import androidx.test.espresso.Espresso.onData
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.Espresso.pressBack
+import androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu
+import androidx.test.espresso.action.ViewActions.*
+import androidx.test.espresso.assertion.ViewAssertions.*
+import androidx.test.espresso.matcher.ViewMatchers.*
+
+import jp.co.yumemi.android.code_check.R
+
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+import org.hamcrest.TypeSafeMatcher
+import org.hamcrest.core.IsInstanceOf
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+import org.hamcrest.Matchers.allOf
+import org.hamcrest.Matchers.anything
+import org.hamcrest.Matchers.`is`
+
+@LargeTest
+@RunWith(AndroidJUnit4::class)
+class SearchFragmentTest {
+
+    @Rule
+    @JvmField
+    var mActivityScenarioRule = ActivityScenarioRule(MainActivity::class.java)
+
+    // searchFragmentが正しく表示されるかどうかのテスト
+    // recyclerViewの内部のテストは実装工数的に今は実装しない
+    @Test
+    fun searchFragmentTest() {
+        val textInputEditText = onView(
+            allOf(withId(R.id.searchInputText), isDisplayed())
+        )
+        textInputEditText.perform(replaceText("test"), closeSoftKeyboard())
+
+        val recyclerView = onView(
+            allOf(withId(R.id.rvRepositoryList), isDisplayed())
+        )
+        recyclerView.check(matches(isDisplayed()))
+        textInputEditText.perform(pressImeActionButton())
+    }
+}

--- a/app/src/test/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositoryAdapterTest.kt
+++ b/app/src/test/kotlin/jp/co/yumemi/android/code_check/ui/search/RepositoryAdapterTest.kt
@@ -1,0 +1,55 @@
+package jp.co.yumemi.android.code_check.ui.search
+
+import org.junit.Test
+import org.junit.Assert.*
+import jp.co.yumemi.android.code_check.data.model.RepositoryInfo
+
+
+class TaskDiffCallbackTest {
+
+    // 異なるアイテムが同じではないことをテスト
+    @Test
+    fun `areItemsTheSame with different items should return false`() {
+        // 異なるリポジトリ情報を持つ二つのオブジェクトを作成
+        val repo1 = RepositoryInfo("repo1", "", "", 0, 0, 0, 0)
+        val repo2 = RepositoryInfo("repo2", "", "", 0, 0, 0, 0)
+        val callback = TaskDiffCallback()
+
+        // アイテムが異なるため、falseを返すことを期待
+        assertFalse(callback.areItemsTheSame(repo1, repo2))
+    }
+
+    // 同一のアイテムが同じであることをテスト
+    @Test
+    fun `areItemsTheSame with same items should return true`() {
+        // 同一のリポジトリ情報を持つオブジェクトを作成
+        val repo = RepositoryInfo("repo", "", "", 0, 0, 0, 0)
+        val callback = TaskDiffCallback()
+
+        // 同一のオブジェクトを比較するため、trueを返すことを期待
+        assertTrue(callback.areItemsTheSame(repo, repo))
+    }
+
+    // 異なる内容のアイテムが同一でないことをテスト
+    @Test
+    fun `areContentsTheSame with different content should return false`() {
+        // 同一のリポジトリ名でも異なるプログラミング言語を持つ二つのオブジェクトを作成
+        val repo1 = RepositoryInfo("repo", "", "Java", 10, 20, 5, 3)
+        val repo2 = RepositoryInfo("repo", "", "Kotlin", 10, 20, 5, 3)
+        val callback = TaskDiffCallback()
+
+        // 内容が異なるため、falseを返すことを期待
+        assertFalse(callback.areContentsTheSame(repo1, repo2))
+    }
+
+    // 同一内容のアイテムが同じであることをテスト
+    @Test
+    fun `areContentsTheSame with same content should return true`() {
+        // 同一のリポジトリ情報を持つオブジェクトを作成
+        val repo = RepositoryInfo("repo", "", "Java", 10, 20, 5, 3)
+        val callback = TaskDiffCallback()
+
+        // 全ての属性が同じため、trueを返すことを期待
+        assertTrue(callback.areContentsTheSame(repo, repo))
+    }
+}


### PR DESCRIPTION
テストコードを導入
## 既存の修正
アプリのパッケージ名を確認する統合テストが用意されていたが、パッケージ名とあっておらずテストが通っていなかった

パッケージ名に合わせる形でテスト側を修正

## unit test
List Adapterで使われている、TaskDiffCallbackクラスがテストに適していたためunit testを追加

## ui test
ui testの実験のため、検索画面にui testを導入。

espressoのrecorderをベースに手で修正を加えたテストコードを追加

#### 備考
自分が未経験であり、タスクの残り時間も短いため、unit testとui testをそれぞれ一つずつ追加するだけにとどめた。

close #7 