### PR TITLE
WIP: レポジトリ検索結果を増やす

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/repository/GithubRepository.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/repository/GithubRepository.kt
@@ -9,16 +9,34 @@ import io.ktor.client.request.header
 import io.ktor.client.request.parameter
 import io.ktor.client.statement.HttpResponse
 import jp.co.yumemi.android.code_check.data.model.RepositoryInfo
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import org.json.JSONObject
 
 class GithubRepository(private val context: Context) {
     private val client = HttpClient(Android)
 
-    suspend fun searchRepositories(query: String): List<RepositoryInfo> {
+    suspend fun fetchAllRepositories(query: String): List<RepositoryInfo> =
+        coroutineScope {
+            val pages = listOf(1, 2, 3) // 例えば最初の3ページを取得
+            pages.map { page ->
+                async {
+                    searchRepositories(query, page)
+                }
+            }.awaitAll().flatten() // すべてのページからの結果を平坦化して結合
+        }
+
+    suspend fun searchRepositories(
+        query: String,
+        page: Int,
+    ): List<RepositoryInfo> {
         val response: HttpResponse =
             client.get("https://api.github.com/search/repositories") {
                 header("Accept", "application/vnd.github.v3+json")
                 parameter("q", query)
+                parameter("page", page)
+                parameter("per_page", 100) // ページあたりのアイテム数を100に設定
             }
 
         val json = JSONObject(response.receive<String>())

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/SearchViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/SearchViewModel.kt
@@ -2,7 +2,6 @@
  * Copyright © 2021 YUMEMI Inc. All rights reserved.
  */
 package jp.co.yumemi.android.code_check.ui.search
-
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
@@ -14,20 +13,58 @@ import javax.inject.Inject
 
 class SearchViewModel
     @Inject
-    constructor(private val repository: GithubRepository) : ViewModel() {
+    constructor(
+        private val repository: GithubRepository,
+    ) : ViewModel() {
         private val _searchResult = MutableLiveData<List<RepositoryInfo>>()
         val searchResult: LiveData<List<RepositoryInfo>> get() = _searchResult
 
         private val _errorMessage = MutableLiveData<String>()
         val errorMessage: LiveData<String> get() = _errorMessage
 
-        fun searchResults(inputText: String) {
+        private var currentPage = 1
+        private var hasNextPage = true
+        private var currentQuery = ""
+
+        fun searchResults(
+            inputText: String,
+            page: Int = 1,
+        ) {
+            currentQuery = inputText
             viewModelScope.launch {
                 try {
-                    _searchResult.value = repository.searchRepositories(inputText)
+                    val results = repository.searchRepositories(inputText, page)
+                    if (results.isEmpty() && page != 1) {
+                        hasNextPage = false
+                    } else {
+                        _searchResult.postValue(results)
+                        if (page == 1) {
+                            preloadNextPage() // 最初のページのロード後に次のページをプリロード
+                        }
+                    }
                 } catch (e: Exception) {
                     _errorMessage.postValue("エラーが発生しました: ${e.message}")
                 }
+            }
+        }
+
+        private fun preloadNextPage() {
+            if (hasNextPage) {
+                searchResults(currentQuery, currentPage + 1)
+            }
+        }
+
+        fun loadNextPage() {
+            if (hasNextPage) {
+                currentPage++
+                searchResults(currentQuery, currentPage)
+            }
+        }
+
+        fun loadPreviousPage() {
+            if (currentPage > 1) {
+                currentPage--
+                searchResults(currentQuery, currentPage)
             }
         }
     }

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -4,7 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".MainActivity">
+    tools:context=".ui.search.SearchFragment">
 
     <com.google.android.material.card.MaterialCardView
         android:id="@+id/searchBar"
@@ -13,7 +13,6 @@
         android:layout_margin="12dp"
         app:cardCornerRadius="12dp"
         app:cardElevation="8dp"
-        app:layout_constraintBottom_toTopOf="@id/rvRepositoryList"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
@@ -27,10 +26,6 @@
             app:endIconMode="clear_text"
             app:endIconTint="@android:color/darker_gray"
             app:hintTextColor="@android:color/darker_gray"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
             app:startIconDrawable="@android:drawable/ic_menu_search"
             app:startIconTint="@android:color/darker_gray">
 
@@ -45,28 +40,44 @@
                 android:textSize="12sp" />
 
         </com.google.android.material.textfield.TextInputLayout>
-
     </com.google.android.material.card.MaterialCardView>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rvRepositoryList"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/nextPageButton"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/searchBar" />
 
-    <!-- 検索待ちのローディングインジケーター -->
     <ProgressBar
         android:id="@+id/progressBar"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="16dp"
-        app:layout_constraintTop_toTopOf="parent"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/nextPageButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/label_next_page_button"
         app:layout_constraintBottom_toBottomOf="parent"
-        android:visibility="gone"/> <!-- 初期状態で非表示 -->
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintRight_toLeftOf="@+id/prevPageButton" />
+
+    <Button
+        android:id="@+id/prevPageButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/label_previous_page_button"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintLeft_toRightOf="@+id/nextPageButton" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,8 @@
 
     // レポジトリ検索ページ
     <string name="hint_search_repository">レポジトリ名かユーザー名で検索できるよ~</string>
+    <string name="label_next_page_button">次のページ</string>
+    <string name="label_previous_page_button">前のページ</string>
 
     // レポジトリ詳細ページ
     <string name="pattern_written_language">使用言語\n%s</string>


### PR DESCRIPTION
## 概要
- レポジトリ検索を30件ではなく全件取得できるようにする
- 1ページあたりは30件ずつ表示し、ページネーション機能を追加


## 詳細
- `SearchViewModel` にページネーションのためのロジックを追加する。現在のページ番号を追跡し、次または前のページのデータを取得する機能を含む。
- `SearchFragment` に次のページと前のページへ移動するためのUIコントロール（ボタン）を追加する。
- 各ページは非同期的にデータを取得し、最初のページの読み込み完了後に自動的に次のページをプリロードするように設定する。
- ユーザーが最後のページに達した場合、次のページへのボタンを非表示にすることで、存在しないページへのアクセスを防ぐ。

## 関連issue
#27 

## 現状
時間の問題で、ほとんど実装できていません。

